### PR TITLE
Setting rstudio password is now REQUIRED. Container will error otherwise

### DIFF
--- a/postgresql/docker-compose.yml
+++ b/postgresql/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     ports:
       - "8787:8787"
       - "6311:6311"
+    environment:
+      - PASSWORD=mypass
 
   broadsea-webtools:
     image: ohdsi/broadsea-webtools


### PR DESCRIPTION
rstudio no longer defines a default password.
Thus container will error when instantiated if no password is passed.

Also the classical default password 'rstudio' is no longer valid.

we can pass that password as an environment variable named PASSWORD of the docker-compose file, here I use 'mypass' as a default password.