### PR TITLE
Update SQLServerDialect to 2012

### DIFF
--- a/sqlserver/docker-compose.yml
+++ b/sqlserver/docker-compose.yml
@@ -25,7 +25,7 @@ services:
      - datasource.username=secret-user-name
      - datasource.password=secret-user-password
      - spring.jpa.properties.hibernate.default_schema=ohdsi
-     - spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.SQLServer2008Dialect
+     - spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.SQLServer2012Dialect
      - spring.batch.repository.tableprefix=secret-database-name.ohdsi.BATCH_
      - flyway.datasource.driverClassName=com.microsoft.sqlserver.jdbc.SQLServerDriver
      - flyway.datasource.url=jdbc:sqlserver://192.168.99.100;databasename=secret-database-name


### PR DESCRIPTION
The current dialect (2008) does not handle sequences.  The minimum required SQL version is 2012, due to our dependency on sequences.
