### PR TITLE
Added Achilles container image build

### DIFF
--- a/.github/workflows/build-achilles-image.yaml
+++ b/.github/workflows/build-achilles-image.yaml
@@ -1,0 +1,52 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - "master"
+    tags:
+      - "achilles-image/v*"
+  pull_request:
+    branches:
+      - "master"
+
+jobs:
+  build:
+    name: Build Achilles Container Image
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Container Image Meta
+        id: image_meta
+        uses: docker/metadata-action@v3
+        with:
+          images: docker.io/ohdsi/achilles
+          tags: |
+            type=match,pattern=achilles-image-v(.*),group=1,enable=${{github.event_name != 'pull_request'}}
+            type=sha
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        if: github.event_name != 'pull_request'
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Cache layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Build and push
+        id: image_build
+        uses: docker/build-push-action@v2
+        with:
+          context: "{{defaultContext}}:achilles-image"
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          push: ${{github.event_name != 'pull_request'}}
+          tags: ${{ steps.image_meta.outputs.tags }}
+          labels: ${{ steps.image_meta.outputs.labels }}

--- a/achilles-image/Dockerfile
+++ b/achilles-image/Dockerfile
@@ -1,0 +1,63 @@
+# syntax=docker/dockerfile:1.4
+FROM ubuntu:20.04
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+WORKDIR /opt/achilles
+ENV DATABASECONNECTOR_JAR_FOLDER="/opt/achilles/drivers"
+
+RUN <<EOF
+groupadd -g 10001 achilles
+useradd -u 10001 -g achilles achilles
+mkdir ./output
+mkdir ./drivers
+chown -R achilles .
+EOF
+
+# hadolint ignore=DL3008
+RUN <<EOF
+apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+  software-properties-common \
+  openjdk-11-jre \
+  openjdk-11-jre-headless \
+  libxml2-dev \
+  locales \
+  wget
+
+echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
+locale-gen en_US.utf8
+/usr/sbin/update-locale LANG=en_US.UTF-8
+
+wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc
+add-apt-repository "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -cs)-cran40/"
+add-apt-repository "ppa:c2d4u.team/c2d4u4.0+"
+apt-get update
+
+DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+  r-base \
+  r-base-dev \
+  r-cran-httr \
+  r-cran-remotes \
+  r-cran-rjava \
+  r-cran-rjson \
+  r-cran-littler \
+  r-cran-docopt
+
+rm -rf /var/lib/apt/lists/*
+R CMD javareconf
+ln -s /usr/lib/R/site-library/littler/examples/install2.r /usr/local/bin/install2.r
+EOF
+
+RUN <<EOF
+install2.r --error \
+  ParallelLogger \
+  SqlRender \
+  DatabaseConnector
+R -e "library(DatabaseConnector); downloadJdbcDrivers('postgresql')"
+EOF
+
+RUN R -e "remotes::install_github('OHDSI/Achilles@c6b7adb6330e75c2311880db2eb3dc4c12341c4f')"
+
+COPY entrypoint.r ./
+
+USER 10001:10001
+CMD ["Rscript", "entrypoint.r"]

--- a/achilles-image/entrypoint.r
+++ b/achilles-image/entrypoint.r
@@ -1,0 +1,122 @@
+#!/usr/bin/Rscript
+
+# Load Achilles and httr.
+library(Achilles)
+library(httr)
+
+# Get passed environment variables.
+env_var_names <- list(
+  "ACHILLES_SOURCE",
+  "ACHILLES_DB_URI",
+  "ACHILLES_DB_USERNAME",
+  "ACHILLES_DB_PASSWORD",
+  "ACHILLES_CDM_SCHEMA",
+  "ACHILLES_VOCAB_SCHEMA",
+  "ACHILLES_RES_SCHEMA",
+  "ACHILLES_OUTPUT_BASE",
+  "ACHILLES_CDM_VERSION",
+  "ACHILLES_NUM_THREADS"
+)
+env_vars <- Sys.getenv(env_var_names, unset = NA)
+
+# Replace unset environement variables with defaults.
+default_vars <-
+  list(
+    "N/A",
+    "postgresql://localhost/postgres",
+    "",
+    "",
+    "public",
+    "public",
+    "public",
+    "./output",
+    "5",
+    "1"
+  )
+env_vars[is.na(env_vars)] <- default_vars[is.na(env_vars)]
+
+# Otherwise "snow" will go wrong way: https://github.com/cran/snow/blob/b83f63db1072533b85e6e3146c51b7fca007425c/R/sock.R#L151
+env_vars$ACHILLES_NUM_THREADS <-
+  as.numeric(env_vars$ACHILLES_NUM_THREADS)
+
+# Create name to tag results and output path from ACHILLES_SOURCE and timestamp
+current_datetime <-
+  strftime(Sys.time(), format = "%Y-%m-%dT%H.%M.%S")
+output_path <-
+  paste(env_vars$ACHILLES_OUTPUT_BASE,
+        env_vars$ACHILLES_SOURCE,
+        current_datetime,
+        sep = "/")
+dir.create(
+  output_path,
+  showWarnings = FALSE,
+  recursive = TRUE,
+  mode = "0755"
+)
+
+# Parse DB URI into pieces.
+db_conf <- parse_url(env_vars$ACHILLES_DB_URI)
+
+# Some connection packages need the database on the server argument.
+server <- paste(db_conf$hostname, db_conf$path, sep = "/")
+
+# Create connection details using DatabaseConnector utility.
+db_username <-
+  ifelse(
+    env_vars$ACHILLES_DB_USERNAME == "" |
+      is.na(env_vars$ACHILLES_DB_USERNAME),
+    db_conf$username,
+    env_vars$ACHILLES_DB_USERNAME
+  )
+db_password <-
+  ifelse(
+    env_vars$ACHILLES_DB_PASSWORD == "" |
+      is.na(env_vars$ACHILLES_DB_PASSWORD),
+    db_conf$password,
+    env_vars$ACHILLES_DB_PASSWORD
+  )
+connectionDetails <- createConnectionDetails(
+  dbms = db_conf$scheme,
+  user = db_username,
+  password = db_password,
+  server = server,
+  port = db_conf$port
+)
+
+args <- commandArgs(trailingOnly = TRUE)
+
+createIndices <-
+  (db_conf$scheme != "redshift" && db_conf$scheme != "netezza")
+
+if (length(args) == 0 || args[1] != "heel") {
+  # Run Achilles report and generate data in the results schema.
+  achillesResults <- achilles(
+    connectionDetails,
+    cdmDatabaseSchema = env_vars$ACHILLES_CDM_SCHEMA,
+    resultsDatabaseSchema = env_vars$ACHILLES_RES_SCHEMA,
+    vocabDatabaseSchema = env_vars$ACHILLES_VOCAB_SCHEMA,
+    sourceName = env_vars$ACHILLES_SOURCE,
+    cdmVersion = env_vars$ACHILLES_CDM_VERSION,
+    createIndices = createIndices,
+    numThreads = env_vars$ACHILLES_NUM_THREADS
+  )
+} else {
+  # Run Achilles Heel only
+  achillesHeel(
+    connectionDetails,
+    cdmDatabaseSchema = env_vars$ACHILLES_CDM_SCHEMA,
+    resultsDatabaseSchema = env_vars$ACHILLES_RES_SCHEMA,
+    vocabDatabaseSchema = env_vars$ACHILLES_VOCAB_SCHEMA,
+    cdmVersion = env_vars$ACHILLES_CDM_VERSION,
+    numThreads = env_vars$ACHILLES_NUM_THREADS
+  )
+}
+
+# Export Achilles results to output path in JSON format.
+exportToJson(
+  connectionDetails,
+  cdmDatabaseSchema = env_vars$ACHILLES_CDM_SCHEMA,
+  resultsDatabaseSchema = env_vars$ACHILLES_RES_SCHEMA,
+  vocabDatabaseSchema = env_vars$ACHILLES_VOCAB_SCHEMA,
+  outputPath = output_path
+)


### PR DESCRIPTION
As per the discussion in https://github.com/OHDSI/Achilles/discussions/536, this adds a workflow for building Achilles as a container image.

This is done as a preparation for moving the OHDSI stack Helm chart from my private repository over at https://github.com/chgl/charts/tree/master/charts/ohdsi (see https://github.com/OHDSI/Broadsea/issues/23) to the OHDSI community. Once an official container image for Achilles is available, the one I used for the chart (ghcr.io/chgl/ohdsi/achilles:master) can be replaced and therfore all images can be traced back to OHDSI repositories. The script and Dockerfile is based on https://github.com/OHDSI/Achilles/pull/510 and https://github.com/OHDSI/Achilles/pull/507.

The included workflow will build a new image on every push to master, tagged using that commits SHA, and every time a git tag `achilles-image/v*` is created. Depending on the prefered versioning startegy, this could for example allow tagging new images as `v1.0.0-achilles-1.6.3`, or maybe more accurately in its current setup: `v1.0.0-achilles-c6b7adb` to reference the current achilles version as well as allowing for independently versioning the image itself.

In order for this to work, two secrets will have to be created for the broadsea repository: `DOCKERHUB_USERNAME ` and `DOCKERHUB_TOKEN` containing a username and DockerHub PAT to push to the `ohdsi` group respectively; similar to https://github.com/OHDSI/WebAPI/pull/1690.

If accepted, I'll prepare a new PR next that will setup the repository to include the Helm chart currently hosted at https://github.com/chgl/charts/tree/master/charts/ohdsi updated to use the new Achilles image.