### PR TITLE
Fixed solr endpoint variable name in webapi

### DIFF
--- a/ohdsi-webapi.yml
+++ b/ohdsi-webapi.yml
@@ -36,7 +36,7 @@ services:
       FLYWAY_BASELINEDESCRIPTION: Base Migration
       SECURITY_CORS_ENABLED: "true"
       SECURITY_ORIGIN: "${HTTP_TYPE}://${BROADSEA_HOST}"
-      SOLR_VOCAB_ENDPOINT: "${SOLR_VOCAB_ENDPOINT}"
+      SOLR_ENDPOINT: "${SOLR_VOCAB_ENDPOINT}"
 
       # Security provider enabling/disabling
       


### PR DESCRIPTION
Resolves #96 

Inadvertently had changed the name to SOLR_VOCAB_ENDPOINT, when WebAPI expects SOLR_ENDPOINT