### PR TITLE
fix GITHUB_PAT usage in ares Dockerfile

### DIFF
--- a/ares/Dockerfile
+++ b/ares/Dockerfile
@@ -2,7 +2,8 @@ FROM docker.io/rocker/r-ver:4.2.3
 ARG ACHILLES_GITHUB_REF=main
 ARG ARESINDEXER_GITHUB_REF=dockerfile
 
-RUN echo 'GITHUB_PAT=' /run/secrets/GITHUB_PAT >> /root/.Renviron
+RUN --mount=type=secret,id=GITHUB_PAT \
+    echo GITHUB_PAT=$(cat /run/secrets/GITHUB_PAT) >> /root/.Renviron
 
 RUN <<EOF
 apt-get update

--- a/compose/aresindexer.yml
+++ b/compose/aresindexer.yml
@@ -3,12 +3,14 @@ version: '3.9'
 services:
 
   broadsea-run-aresindexer:
-    build: ../ares
+    build: 
+      context: ../ares
+      secrets:
+        - GITHUB_PAT
     platform: "linux/amd64"
     container_name: broadsea-run-aresindexer
     secrets:
       - CDM_CONNECTIONDETAILS_PASSWORD
-      - GITHUB_PAT
     environment:
       CDM_CONNECTIONDETAILS_DBMS: ${CDM_CONNECTIONDETAILS_DBMS}
       CDM_CONNECTIONDETAILS_USER: ${CDM_CONNECTIONDETAILS_USER}


### PR DESCRIPTION
This PR fixes #144 by adding GITHUB_PAT as build secret in the corresponding compose file and fixes how it is obtained in the Dockerfile itself