### PR TITLE
Update Traefik to v2.11.33

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ volumes:
 services:
   
   traefik:
-    image: docker.io/library/traefik:v2.11.2
+    image: docker.io/library/traefik:v2.11.33
     container_name: traefik
     restart: unless-stopped
     ipc: none


### PR DESCRIPTION
This restores the compatibility with Docker v29, which raised the minimum API version.

See https://github.com/traefik/traefik/issues/12253